### PR TITLE
Drag-and-drop support

### DIFF
--- a/howm-dnd.el
+++ b/howm-dnd.el
@@ -4,7 +4,7 @@
   (let* ((target (dnd-get-local-file-name uri t)))
     (if target
         (progn
-		  (insert ">>> ~/")
+          (insert ">>> ~/")
           (insert (file-relative-name target "~")))
       (message "Failed to drag-and-drop a link to file!"))
     action))

--- a/howm-dnd.el
+++ b/howm-dnd.el
@@ -1,0 +1,19 @@
+;;; howm-dnd.el --- Drag-and-drop support
+(defun howm-drag-and-drop (uri action)
+  "Drag-and-drop files into a Howm buffer to link them."
+  (let* ((target (dnd-get-local-file-name uri t)))
+    (if target
+        (progn
+		  (insert ">>> ~/")
+          (insert (file-relative-name target "~")))
+      (message "Failed to drag-and-drop a link to file!"))
+    action))
+
+(defun howm-drag-and-drop-setup ()
+  "Setup the drag-and-drop handler for local files."
+  (add-to-list 'dnd-protocol-alist '("^file:" . howm-drag-and-drop)))
+
+(add-hook 'howm-mode-hook 'howm-drag-and-drop-setup)
+
+(provide 'howm-dnd)
+;;; howm-dnd.el ends here

--- a/howm.el
+++ b/howm.el
@@ -78,6 +78,7 @@
 (require 'howm-date)
 (require 'howm-reminder)
 (require 'howm-menu)
+(require 'howm-dnd)
 
 ;;; for howmz.el [2006-02-02]
 ;;; http://noir.s7.xrea.com/archives/000136.html


### PR DESCRIPTION
This pull request adds drag-and-drop support: You can now drag a file from e.g. a file manager into Howm, and a Howm link to that file will be added to the note. This makes it easier to refer to various documents and attachments in the filesystem in your notes.

![output](https://github.com/user-attachments/assets/2f0dc3ab-d586-41d6-937c-130931cb09de)

We might want to add a variable like `howm-drag-and-drop` (default: `t`) that can be used to disable this feature. This is because some major modes define their own drag-and-drop handlers (e.g. the `org-attach` system in `org-mode`) which is replaced when Howm's drag-and-drop handler is enabled. I'm not confident about how to correctly add a customization option like `howm-drag-and-drop` to the project, so if you think this is useful then perhaps you could add this :).