### PR TITLE
howm: Update help generation for modes

### DIFF
--- a/howm-menu.el
+++ b/howm-menu.el
@@ -166,14 +166,8 @@ Regexp R1 is replaced by T1 if T1 is a string.
 
 (defun howm-menu-mode ()
   "howm menu
-key	binding
----	-------
-\\[action-lock-magic-return]	Follow link
-\\[action-lock-goto-next-link]	Next link
-\\[action-lock-goto-previous-link]	Prev link
-\\[describe-mode]	This help
-\\[bury-buffer]	Quit
-"
+
+\\{howm-menu-mode-map}"
   (interactive)
   (setq major-mode 'howm-menu-mode
         mode-name "HM")

--- a/howm-mode.el
+++ b/howm-mode.el
@@ -258,28 +258,7 @@ When the mode is enabled, underlines are drawn on texts which match
 to titles of other files. Typing \\[action-lock-magic-return] there,
 you can jump to the corresponding file.
 
-key	binding
----	-------
-\\[action-lock-magic-return]	Follow link
-\\[howm-refresh]	Refresh buffer
-\\[howm-list-all]	List all files
-\\[howm-list-grep]	Search (grep)
-\\[howm-create]	Create new file
-\\[howm-dup]	Duplicate current file
-\\[howm-insert-keyword]	Insert keyword
-\\[howm-insert-date]	Insert date
-\\[howm-insert-dtime]	Insert date with time
-\\[howm-keyword-to-kill-ring]	Copy current keyword to kill ring
-\\[action-lock-goto-next-link]	Go to next link
-\\[action-lock-goto-previous-link]	Go to previous link
-\\[howm-next-memo]	Go to next entry in current buffer
-\\[howm-previous-memo]	Go to previous entry in current buffer
-\\[howm-first-memo]	Go to first entry in current buffer
-\\[howm-last-memo]	Go to last entry in current buffer
-\\[howm-create-here]	Add new entry to current buffer
-\\[howm-create-interactively]	Create new file interactively (not recommended)
-\\[howm-random-walk]	Browse random entries automtically
-"
+\\{howm-mode-map}"
   :init-value nil ;; default = off
   :lighter howm-lighter ;; mode-line
   :keymap (mapcar (lambda (entry)

--- a/howm-reminder.el
+++ b/howm-reminder.el
@@ -405,12 +405,7 @@ and `howm-simulate-todo-reset'."
   "Major mode for a time machine simulation of the todo list in howm.
 (Tips) Type C-u 30 \\[howm-simulate-todo-next-date] to simulate 30 days later.
 
-key	binding
----	-------
-\\[howm-simulate-todo-next-date]	Simulate the next date
-\\[howm-simulate-todo-previous-date]	Simulate the previous date
-\\[howm-simulate-todo-reset]	Reset to today
-"
+\\{howm-simulate-todo-mode-map}"
   ;; major mode just for additional key bindings
   (howm-view-summary-mode-body))
 (let ((m howm-simulate-todo-mode-map))

--- a/howm-view.el
+++ b/howm-view.el
@@ -168,34 +168,8 @@ This is a shameful global variable and should be clearned in future.")
 
 (riffle-define-derived-mode howm-view-summary-mode riffle-summary-mode "HowmS"
   "memo viewer (summary mode)
-key	binding
----	-------
-\\[howm-view-summary-open]	Open file
-\\[next-line]	Next item
-\\[previous-line]	Previous item
-\\[riffle-pop-or-scroll-other-window]	Pop and scroll contents
-\\[scroll-other-window-down]	Scroll contents
-\\[riffle-scroll-other-window]	Scroll contents one line
-\\[riffle-scroll-other-window-down]	Scroll contents one line
-\\[riffle-summary-to-contents]	Concatenate all contents
-\\[howm-view-summary-next-section]	Next file (Skip items in the same file)
-\\[howm-view-summary-previous-section]	Previous file (Skip items in the same file)
-\\[howm-view-filter-uniq]	Remove duplication of same file
-\\[howm-view-summary-shell-command]	Execute command in inferior shell
 
-\\[delete-other-windows]	Delete contents window
-\\[riffle-pop-window]	Pop contents window
-\\[riffle-toggle-window]	Toggle contents window
-\\[howm-list-toggle-title]	Show/Hide Title
-
-\\[howm-view-filter]	Filter (by date, contents, etc.)
-\\[howm-view-filter-by-contents]	Search (= filter by contents)
-\\[howm-view-sort]	Sort (by date, summary line, etc.)
-\\[howm-view-sort-reverse]	Reverse order
-\\[howm-view-dired]	Invoke Dired-X
-\\[describe-mode]	This help
-\\[riffle-kill-buffer]	Quit
-"
+\\{howm-view-summary-mode-map}"
   (howm-view-summary-mode-body))
 
 (defun howm-view-summary-mode-body ()
@@ -227,27 +201,8 @@ key	binding
 
 (riffle-define-derived-mode howm-view-contents-mode riffle-contents-mode "HowmC"
   "memo viewer (contents mode)
-key	binding
----	-------
-\\[howm-view-contents-open]	Open file
-\\[next-line]	Next line
-\\[previous-line]	Previous line
-\\[scroll-up]	Scroll up
-\\[scroll-down]	Scroll down
-\\[riffle-scroll-up]	Scroll one line up
-\\[riffle-scroll-down]	Scroll one line down
-\\[riffle-contents-to-summary]	Summary
-\\[riffle-contents-goto-next-item]	Next item
-\\[riffle-contents-goto-previous-item]	Previous item
 
-\\[howm-view-filter]	Filter (by date, contents, etc.)
-\\[howm-view-filter-by-contents]	Search (= filter by contents)
-\\[howm-view-sort]	Sort
-\\[howm-view-sort-reverse]	Reverse order
-\\[howm-view-dired]	Invoke Dired-X
-\\[describe-mode]	This help
-\\[riffle-kill-buffer]	Quit
-"
+\\{howm-view-contents-mode-map}"
 ;   (kill-all-local-variables)
   (make-local-variable 'font-lock-keywords)
   (cheat-font-lock-mode howm-view-font-lock-silent)


### PR DESCRIPTION
Update the modes to generate their help text from the mode-maps, rather than list the contents of the menu manually.

Currently when I type `C-h m` to run `describe-mode`, some of the functions show keybindings of `M-x <function>`, rather than the keys that are bound. We can both fix this and simplify the code, by using the mode-maps like was already done for `howm-remember-mode-map`.