### PR TITLE
Update links to Modus themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Howm is a note-taking tool on Emacs. It is similar to emacs-wiki.el; you can enj
 The following screenshot illustrates the Howm linking system:
 ![screenshot](doc/screenshot.png)
 
-(Colorscheme: [Modus themes](https://github.com/protesilaos/modus-themes/issues/118#issuecomment-2337993946).)
+(Colorscheme: [Modus themes](https://protesilaos.com/emacs/modus-themes#h:7ea8fa66-1cd8-47b0-92b4-9998a3068f85).)
 
 ## Quick start
 

--- a/doc/index-j.html
+++ b/doc/index-j.html
@@ -84,10 +84,8 @@ Emacs で断片的なメモをどんどんとるための環境です.
 
 <h2>こんな雰囲気</h2>
 
-<p>
-<a href="screenshot.png"><img alt="screen shot" src="screenshot.png" width="50%"></a>
-<a href="https://github.com/protesilaos/modus-themes/issues/117#issuecomment-2337993946">カラー設定: Modus themes</a>
-</p>
+<p><a href="screenshot.png"><img alt="screen shot" src="screenshot.png" width="50%"></a></p>
+<a href="https://protesilaos.com/emacs/modus-themes#h:7ea8fa66-1cd8-47b0-92b4-9998a3068f85">カラー設定: Modus themes</a>
 
 <h3>次のように書くだけでリンク</h3>
 <ul>

--- a/doc/index.html
+++ b/doc/index.html
@@ -34,7 +34,7 @@ it can be combined with any format.
 
 The following screenshot illustrates the Howm linking system:
 <p><img alt="screen shot" src="screenshot.png" style="max-height: 90%; max-width: 90%; height: auto; width: auto;"></p>
-(Colorscheme: <a href="https://github.com/protesilaos/modus-themes/issues/118#issuecomment-2337993946">Modus themes</a>.)
+(Colorscheme: <a href="https://protesilaos.com/emacs/modus-themes#h:7ea8fa66-1cd8-47b0-92b4-9998a3068f85">Modus themes</a>.)
 
 <hr>
 


### PR DESCRIPTION
Prot added the instructions for how to theme Howm [in the official Modus documentation](https://protesilaos.com/emacs/modus-themes#h:7ea8fa66-1cd8-47b0-92b4-9998a3068f85), which might therefore be a better resource to link to than the previous Github issue. This PR updates the documentation links accordingly.