### PR TITLE
Avoid double-splitting windows when display-buffer-base-action is non-nil

### DIFF
--- a/riffle.el
+++ b/riffle.el
@@ -470,7 +470,8 @@ snap://Info-mode/emacs#File Variables
                                    even-window-heights))
             ;; Don't split windows further even when
             ;; riffle-pop-to-buffer is called twice.
-            (pop-up-windows nil))
+            (pop-up-windows nil)
+            (display-buffer-base-action nil))
         (pop-to-buffer buf)))))
 
 ;; 'Place' is line number at now


### PR DESCRIPTION
If you set `display-buffer-base-action` like so:

```elisp
(setopt display-buffer-base-action
          '((display-buffer-pop-up-window)))
```

then calling `howm-list-all` will create multiple, duplicate windows. There's some code that addresses this by binding `pop-up-windows` to `nil`; this PR does the same for `display-buffer-base-action` to avoid the multiple splits.

