### PR TITLE
add howm-recent-excluded-files-regexp option

### DIFF
--- a/howm-common.el
+++ b/howm-common.el
@@ -31,6 +31,19 @@
                               (funcall comparer (car x) (car y))))))
     (mapcar #'cdr sorted)))
 
+(defun howm-recent-items-filter (folder-items)
+  "Remove objects from FOLDER-ITEMS.
+The objects removed are those matching
+`howm-menu-recent-excluded-files-regexp'."
+  (if howm-recent-excluded-files-regexp
+      (seq-remove
+       (lambda (x)
+         (string-match-p
+          howm-recent-excluded-files-regexp
+          (car x)))
+       folder-items)
+    folder-items))
+
 (defun howm-subdirectory-p (dir target &optional strict)
   "For the directory DIR, check whether TARGET is under it.
 When TARGET and DIR are same, (not STRICT) is returned."

--- a/howm-common.el
+++ b/howm-common.el
@@ -34,7 +34,7 @@
 (defun howm-recent-items-filter (folder-items)
   "Remove objects from FOLDER-ITEMS.
 The objects removed are those matching
-`howm-menu-recent-excluded-files-regexp'."
+`howm-recent-excluded-files-regexp'."
   (if howm-recent-excluded-files-regexp
       (seq-remove
        (lambda (x)

--- a/howm-menu.el
+++ b/howm-menu.el
@@ -751,16 +751,18 @@ ITEM-LIST is list of items which should be shown."
          (sorted (howm-sort (lambda (f) (funcall h-r-m-evaluator f))
                             #'howm-view-string>
                             (mapcar #'howm-item-name
-                                    (howm-folder-items howm-directory t))))
+                                    (howm-recent-items-filter
+                                     (howm-folder-items
+                                      howm-directory t)))))
          (files (howm-first-n sorted num)))
     (let ((r (howm-menu-recent-regexp)))
       (if randomp
           (cl-mapcan (lambda (f)
-                            (let ((is (howm-view-search-items r (list f)
-                                                              summarizer)))
-                              (and is (list (nth (random (length is))
-                                                 is)))))
-                          files)
+                       (let ((is (howm-view-search-items r (list f)
+                                                         summarizer)))
+                         (and is (list (nth (random (length is))
+                                            is)))))
+                     files)
         (howm-first-n (howm-view-search-items r files summarizer) num)))))
 
 (defun howm-menu-recent-regexp ()

--- a/howm-mode.el
+++ b/howm-mode.el
@@ -365,7 +365,8 @@ key	binding
   (let* ((d (or days howm-list-recent-days))
          (now (current-time))
          (from (howm-days-before now d))
-         (item-list (howm-folder-items howm-directory t)))
+         (item-list (howm-recent-items-filter
+                     (howm-folder-items howm-directory t))))
     (howm-normalize-show "" (howm-filter-items-by-mtime item-list from now))
     ;; clean me [2003-11-30]
     (cond ((howm-list-title-p) t)  ;; already done in howm-normalize-show

--- a/howm-vars.el
+++ b/howm-vars.el
@@ -575,6 +575,15 @@ if `howm-list-normalizer' is non-nil."
   :type 'boolean
   :group 'howm-sort)
 
+(defcustom howm-recent-excluded-files-regexp nil
+  "Regexp matching names of files to exclude from recents.
+This affects the files shown in the recents section of the
+Howm-menu, as well as the files listed by `howm-list-recent'."
+  :type '(radio (const :tag "Default" nil)
+                regexp)
+  :group 'howm-menu-reminder
+  :group 'howm-files)
+
 ;;
 ;; Title
 ;;


### PR DESCRIPTION
I followed the quick-start guide in the read-me to integrate Howm with Org-mode.  It works very well!

But there's one problem.  If I make a minor change to one of the notes in my old org-mode file, the mtime for that file gets updated, and then *all* of its hundreds of notes are treated as recent notes, which pushes my Howm notes out of view in the recent list.

This patch adds a user-option to exclude certain files from the recent-note lists.  It also adds a function `howm-recent-items-filter`, and adjusts the `howm-recent-menu` and `howm-list-recent` functions to apply the filter if the option has been set.

This still allows headings in excluded files to be searched. They are only excluded from listings of recent files.