### PR TITLE
Fix double calls to howm-template-string in howm-create-file-with-title

### DIFF
--- a/howm-menu.el
+++ b/howm-menu.el
@@ -509,7 +509,7 @@ When this is nil, delete-region is used instead, and bug appears.")
 (defun howm-open-today ()
   (interactive)
   (and (howm-create-file t)
-       (howm-insert-template ""))
+       (howm-insert-template "" (howm-template-string)))
   (howm-set-mode))
 
 (defun howm-open-past (&optional days-before)

--- a/howm-misc.el
+++ b/howm-misc.el
@@ -554,9 +554,9 @@ and replace a sub-expression, e.g.
 
 ;; named note
 
-(defun howm-open-named-file ()
+(defun howm-open-named-file (which-template)
   "Ask a file name and open it as howm note if it is under howm directory."
-  (interactive)
+  (interactive "p")
   (let* ((item-dir (lambda (item) (file-name-directory (howm-item-name item))))
          (dir (cond ((eq major-mode 'howm-view-summary-mode)
                      (funcall item-dir (howm-view-summary-current-item)))
@@ -569,7 +569,7 @@ and replace a sub-expression, e.g.
     (if (file-exists-p fname)
         (howm-set-mode)
       (progn
-        (howm-insert-template "")
+        (howm-insert-template "" (howm-template-string which-template))
         (howm-create-finish)))))
 
 ;; imitation of remember.el

--- a/howm-mode.el
+++ b/howm-mode.el
@@ -881,18 +881,20 @@ We need entire-match in order to
   (howm-create which-template t))
 
 (defun howm-create-file-with-title (title &optional
-                                    which-template not-use-file here content)
+                                          which-template not-use-file here content)
   (let ((b (current-buffer)))
     (when (not here)
       (howm-create-file))
     (cond ((howm-buffer-empty-p) nil)
           ((and here howm-create-here-just) (beginning-of-line))
           (t (howm-create-newline)))
-    (let ((p (point))
-          (insert-f (lambda (switch)
-                      (howm-insert-template (if switch title "")
-                                            b which-template (not switch))))
-          (use-file (not not-use-file)))
+    (let* ((p (point))
+           (template-string (howm-template-string which-template b))
+           (insert-f (lambda (switch)
+                       (howm-insert-template (if switch title "")
+                                             template-string
+                                             b (not switch))))
+           (use-file (not not-use-file)))
       ;; second candidate which appears when undo is called
       (let ((end (funcall insert-f not-use-file)))
         (save-excursion
@@ -921,12 +923,12 @@ We need entire-match in order to
     (insert "\n"))
   (insert "\n"))
 
-(defun howm-insert-template (title &optional
-                                   previous-buffer which-template not-use-file)
+(defun howm-insert-template (title template-string &optional
+                                   previous-buffer not-use-file)
   (let* ((beg (point))
          (f (buffer-file-name previous-buffer))
          (af (and f (howm-abbreviate-file-name f))))
-    (insert (howm-template-string which-template previous-buffer))
+    (insert template-string)
     (let* ((date (format-time-string howm-template-date-format))
            (use-file (not not-use-file))
            (file (cond ((not use-file) "")
@@ -944,7 +946,7 @@ when howm-template is a function.
 Set this option to nil if backward compatibility with howm-1.2.4 or earlier
 is necessary.")
 
-(defun howm-template-string (which-template previous-buffer)
+(defun howm-template-string (&optional which-template previous-buffer)
   ;; which-template should be 1, 2, 3, ...
   (setq which-template (or which-template 1))
   (cond ((stringp howm-template) howm-template)


### PR DESCRIPTION
When creating a new note, `howm-insert-template` is called twice to create the second candidate (the version without %file) accessible using undo.

This behavior causes variable `howm-template` to also be called/referred twice.  This seems harmless but if the user customizes this variable and is defined as a function, there can be unintended side effects.  For instance, if the custom function does a completing-read to ask for a template to use, the prompt will show twice.

To fix, move call to `howm-template-string` outside of the lambda function in `howm-create-file-with-title` and then use the resulting value inside of the lambda.