### PR TITLE
Remove matching of current directory when matching file names

### DIFF
--- a/howm-mode.el
+++ b/howm-mode.el
@@ -654,8 +654,8 @@ key	binding
             (wiki-reg (regexp-quote (howm-make-wiki-string keyword)))
             (file-reg (and
                        (stringp keyword)
-                       (format "^%s$"
-                               (regexp-quote (expand-file-name keyword)))))
+                       (format "%s"
+                               (regexp-quote keyword))))
             (case-fold-search howm-keyword-case-fold-search))
         (cl-labels ((check (tag flag reg &optional tag-when-multi-hits)
                         (when flag


### PR DESCRIPTION
Hi @kaorahi san, thank you again for creating howm.  I'm submitting another fix for a bug I am encountering when I do `howm-find-today`, and then shift dates using `howm-date-backward` and `howm-date-forward`.  The search keeps on going for the full 35 days even if I have notes on the previous days.

How to reproduce:
- I am visiting my init.el file which resides in /home/myuser/.emacs.d/init.el for instance
- I do `howm-find-today` to see a list of my notes for today
- I do `howm-date-backward` or `(` to see notes for the previous day
- No note is found and "Not found within 35 days" is shown.

It turns out that whenever the visited buffer lies outside of the howm directory, the file name matching in `howm-normalize` fails due to the regex used.  For the example above, the resulting regex will be `"^/home/myuser/.emacs.d/2025-01-04$"` if today if 2025-01-05.  The proposed fix will change the regex to simply `"2025-01-05"`.