### PR TITLE
fix: make howm-dup respect the howm-prepend setting

### DIFF
--- a/howm-mode.el
+++ b/howm-mode.el
@@ -1007,10 +1007,16 @@ is necessary.")
 (defun howm-dup ()
   (interactive)
   (let* ((r (howm-view-paragraph-region))
-         (s (buffer-substring-no-properties (car r) (cadr r))))
+         (s (buffer-substring-no-properties (car r) (cadr r)))
+         (buffer-empty-p))
     (howm-create-file)
     (howm-set-mode)
-    (insert "\n" s)))
+    (setq buffer-empty-p (howm-buffer-empty-p))
+    (unless buffer-empty-p
+      (howm-create-newline))
+    (insert s)
+    (if (and howm-prepend (not buffer-empty-p))
+        (save-excursion (insert "\n\n")))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Keyword


### PR DESCRIPTION
Hi @kaorahi san, submitting a small change.  I noticed that `howm-dup` always added the duplicated note at the bottom of the file.  This change will make the function add on top of the file if `howm-prepend` is set to `t`.